### PR TITLE
Marker position not updated if metadata already loaded.

### DIFF
--- a/src/markerBar.js
+++ b/src/markerBar.js
@@ -41,16 +41,22 @@ class MarkerBar extends Component {
 
     options.markers.forEach((marker) => this.addChild(marker));
 
-    const onLoadedMetaData = () => {
+    const updateMarkersPosition = () => {
       const duration = player.duration();
 
       options.markers.forEach((marker) => {
-        marker.updatePosition(duration);
+        if (!marker.isDisposed()) {
+          marker.updatePosition(duration);
+        }
       });
-      player.off('loadedmetadata', onLoadedMetaData);
     };
 
-    player.on('loadedmetadata', onLoadedMetaData);
+    // Video Metadata already loaded
+    if (player.readyState() > 0) {
+      updateMarkersPosition();
+    }
+    // In case there was metadata from previous video
+    player.one('loadedmetadata', updateMarkersPosition);
   }
 
   /**


### PR DESCRIPTION
If the markers were created after the video metadata was loaded the
onMetadaLoaded event was never fired and the markers where not
positioned.

I needed the markers to update without that event, as I wanted to 
change the markers displayed on a video that is already playing.

I added a check for readyState greater than 0 (metadata loaded). In that
case the update is performed.

The function is also called the next time the metadata is loaded. This
will happen if meta data was not loaded (as with the previous code),
but also in case that there has been a change of video source and the
markers were positioned according to the old source duration.

Changes to be committed:
	modified:   src/markerBar.js